### PR TITLE
Fix: Rename namespace after move to @ergebnis

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/faker-provider
+ * @see https://github.com/ergebnis/faker-provider
  */
 
 use Ergebnis\PhpCsFixer\Config;
@@ -19,7 +19,7 @@ Copyright (c) 2019 Andreas Möller
 For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 
-@see https://github.com/localheinz/faker-provider
+@see https://github.com/ergebnis/faker-provider
 EOF;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($header));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,45 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.1.0...master`][0.1.0...master].
+For a full diff see [`0.2.0...master`][0.2.0...master].
+
+## [`0.2.0`][0.2.0]
+
+For a full diff see [`0.1.0...0.2.0`][0.1.0...0.2.0].
+
+### Changed
+
+* Renamed vendor namespace `Localheinz` to `Ergebnis` after move to [@ergebnis] ([#18]), by [@localheinz]
+
+  Run
+
+  ```
+  $ composer remove localheinz/faker-provider
+  ```
+
+  and
+
+  ```
+  $ composer require ergebnis/faker-provider
+  ```
+
+  to update.
+
+  Run
+
+  ```
+  $ find . -type f -exec sed -i '.bak' 's/Localheinz\\Faker\\Provider/Ergebnis\\Faker\\Provider/g' {} \;
+  ```
+
+  to replace occurrences of `Localheinz\Faker\Provider` with `Ergebnis\Faker\Provider`.
+
+  Run
+
+  ```
+  $ find -type f -name '*.bak' -delete
+  ```
+
+  to delete backup files created in the previous step.
 
 ### Fixed
 
@@ -20,12 +58,16 @@ For a full diff see [`b2e46fd...0.1.0`][b2e46fd...0.1.0].
 
 * Added `AvatarUrlProvider` which initally allows creating URLs to [avatars.adorable.io](http://avatars.adorable.io) avatars ([#1]), by [@localheinz]
 
-[0.1.0]: https://github.com/localheinz/faker-provider/tag/0.1.0
+[0.1.0]: https://github.com/ergebnis/faker-provider/tag/0.1.0
+[0.2.0]: https://github.com/ergebnis/faker-provider/tag/0.2.0
 
-[b2e46fd...0.1.0]: https://github.com/localheinz/faker-provider/compare/b2e46fd...0.1.0
-[0.1.0...master]: https://github.com/localheinz/faker-provider/compare/0.1.0...master
+[b2e46fd...0.1.0]: https://github.com/ergebnis/faker-provider/compare/b2e46fd...0.1.0
+[0.1.0...0.2.0]: https://github.com/ergebnis/faker-provider/compare/0.1.0...0.2.0
+[0.2.0...master]: https://github.com/ergebnis/faker-provider/compare/0.2.0...master
 
-[#1]: https://github.com/localheinz/faker-provider/pull/1
-[#4]: https://github.com/localheinz/faker-provider/pull/4
+[#1]: https://github.com/ergebnis/faker-provider/pull/1
+[#4]: https://github.com/ergebnis/faker-provider/pull/4
+[#18]: https://github.com/ergebnis/faker-provider/pull/18
 
+[@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # faker-provider
 
-[![Continuous Integration](https://github.com/localheinz/faker-provider/workflows/Continuous%20Integration/badge.svg)](https://github.com/localheinz/faker-provider/actions)
-[![Code Coverage](https://codecov.io/gh/localheinz/faker-provider/branch/master/graph/badge.svg)](https://codecov.io/gh/localheinz/faker-provider)
-[![Latest Stable Version](https://poser.pugx.org/localheinz/faker-provider/v/stable)](https://packagist.org/packages/localheinz/faker-provider)
-[![Total Downloads](https://poser.pugx.org/localheinz/faker-provider/downloads)](https://packagist.org/packages/localheinz/faker-provider)
+[![Continuous Integration](https://github.com/ergebnis/faker-provider/workflows/Continuous%20Integration/badge.svg)](https://github.com/ergebnis/faker-provider/actions)
+[![Code Coverage](https://codecov.io/gh/ergebnis/faker-provider/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/faker-provider)
+[![Latest Stable Version](https://poser.pugx.org/ergebnis/faker-provider/v/stable)](https://packagist.org/packages/ergebnis/faker-provider)
+[![Total Downloads](https://poser.pugx.org/ergebnis/faker-provider/downloads)](https://packagist.org/packages/ergebnis/faker-provider)
 
 Provides additional providers for [`fzaninotto/faker`](https://github.com/fzaninotto/Faker).
 
@@ -12,7 +12,7 @@ Provides additional providers for [`fzaninotto/faker`](https://github.com/fzanin
 Run
 
 ```
-$ composer require --dev localheinz/faker-provider
+$ composer require --dev ergebnis/faker-provider
 ```
 
 ## Usage
@@ -28,7 +28,7 @@ $faker = Factory::create();
 Then add providers like this:
 
 ```php
-use Localheinz\Faker\Provider;
+use Ergebnis\Faker\Provider;
 
 $faker->addProvider(new Provider\AvatarUrlProvider($faker));
 ```
@@ -37,13 +37,13 @@ $faker->addProvider(new Provider\AvatarUrlProvider($faker));
 
 This package provides the following providers for use with [`fzaninotto/faker`](https://github.com/fzaninotto/Faker):
 
-* [`Localheinz\Faker\Provider\AvatarUrlProvider`](https://github.com/localheinz/faker-provider#avatarurlprovider)
+* [`Ergebnis\Faker\Provider\AvatarUrlProvider`](https://github.com/ergebnis/faker-provider#avatarurlprovider)
 
 ### `AvatarUrlProvider`
 
 ```php
+use Ergebnis\Faker\Provider;
 use Faker\Generator;
-use Localheinz\Faker\Provider;
 
 /** @var Generator&Provider\AvatarUrlProvider $faker */
 $url = $faker->adorableAvatarUrl();

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "localheinz/faker-provider",
+  "name": "ergebnis/faker-provider",
   "type": "library",
   "description": "Provides additional providers for fzaninotto/faker.",
   "keywords": [
@@ -7,7 +7,7 @@
     "faker",
     "provider"
   ],
-  "homepage": "https://github.com/localheinz/faker-provider",
+  "homepage": "https://github.com/ergebnis/faker-provider",
   "license": "MIT",
   "authors": [
     {
@@ -18,6 +18,9 @@
   "require": {
     "php": "^7.2",
     "fzaninotto/faker": "^1.9.0"
+  },
+  "replace": {
+    "localheinz/faker-provider": "*"
   },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.0.0",
@@ -37,16 +40,16 @@
   },
   "autoload": {
     "psr-4": {
-      "Localheinz\\Faker\\Provider\\": "src/"
+      "Ergebnis\\Faker\\Provider\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Localheinz\\Faker\\Provider\\Test\\": "test/"
+      "Ergebnis\\Faker\\Provider\\Test\\": "test/"
     }
   },
   "support": {
-    "issues": "https://github.com/localheinz/faker-provider/issues",
-    "source": "https://github.com/localheinz/faker-provider"
+    "issues": "https://github.com/ergebnis/faker-provider/issues",
+    "source": "https://github.com/ergebnis/faker-provider"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c47434013b849cf9db113da4f09e3e7",
+    "content-hash": "e969c4a2d91678450c1b27aa068d6f7f",
     "packages": [
         {
             "name": "fzaninotto/faker",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3,22 +3,22 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method Localheinz\\\\Faker\\\\Provider\\\\AvatarUrlProvider\\:\\:adorableAvatarUrl\\(\\) has parameter \\$identifier with a nullable type declaration\\.$#"
+			message: "#^Method Ergebnis\\\\Faker\\\\Provider\\\\AvatarUrlProvider\\:\\:adorableAvatarUrl\\(\\) has parameter \\$identifier with a nullable type declaration\\.$#"
 			count: 1
 			path: src/AvatarUrlProvider.php
 
 		-
-			message: "#^Method Localheinz\\\\Faker\\\\Provider\\\\AvatarUrlProvider\\:\\:adorableAvatarUrl\\(\\) has parameter \\$identifier with null as default value\\.$#"
+			message: "#^Method Ergebnis\\\\Faker\\\\Provider\\\\AvatarUrlProvider\\:\\:adorableAvatarUrl\\(\\) has parameter \\$identifier with null as default value\\.$#"
 			count: 1
 			path: src/AvatarUrlProvider.php
 
 		-
-			message: "#^Method Localheinz\\\\Faker\\\\Provider\\\\AvatarUrlProvider\\:\\:adorableAvatarUrl\\(\\) has parameter \\$size with a nullable type declaration\\.$#"
+			message: "#^Method Ergebnis\\\\Faker\\\\Provider\\\\AvatarUrlProvider\\:\\:adorableAvatarUrl\\(\\) has parameter \\$size with a nullable type declaration\\.$#"
 			count: 1
 			path: src/AvatarUrlProvider.php
 
 		-
-			message: "#^Method Localheinz\\\\Faker\\\\Provider\\\\AvatarUrlProvider\\:\\:adorableAvatarUrl\\(\\) has parameter \\$size with null as default value\\.$#"
+			message: "#^Method Ergebnis\\\\Faker\\\\Provider\\\\AvatarUrlProvider\\:\\:adorableAvatarUrl\\(\\) has parameter \\$size with null as default value\\.$#"
 			count: 1
 			path: src/AvatarUrlProvider.php
 

--- a/src/AvatarUrlProvider.php
+++ b/src/AvatarUrlProvider.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/faker-provider
+ * @see https://github.com/ergebnis/faker-provider
  */
 
-namespace Localheinz\Faker\Provider;
+namespace Ergebnis\Faker\Provider;
 
 use Faker\Provider;
 

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/faker-provider
+ * @see https://github.com/ergebnis/faker-provider
  */
 
-namespace Localheinz\Faker\Provider\Test\AutoReview;
+namespace Ergebnis\Faker\Provider\Test\AutoReview;
 
 use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
@@ -29,8 +29,8 @@ final class SrcCodeTest extends Framework\TestCase
     {
         self::assertClassesHaveTests(
             __DIR__ . '/../../src',
-            'Localheinz\\Faker\\Provider\\',
-            'Localheinz\\Faker\\Provider\\Test\\Unit\\'
+            'Ergebnis\\Faker\\Provider\\',
+            'Ergebnis\\Faker\\Provider\\Test\\Unit\\'
         );
     }
 }

--- a/test/Unit/AvatarUrlProviderTest.php
+++ b/test/Unit/AvatarUrlProviderTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/faker-provider
+ * @see https://github.com/ergebnis/faker-provider
  */
 
-namespace Localheinz\Faker\Provider\Test\Unit;
+namespace Ergebnis\Faker\Provider\Test\Unit;
 
+use Ergebnis\Faker\Provider\AvatarUrlProvider;
 use Faker\Factory;
 use Faker\Generator;
-use Localheinz\Faker\Provider\AvatarUrlProvider;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Faker\Provider\AvatarUrlProvider
+ * @covers \Ergebnis\Faker\Provider\AvatarUrlProvider
  */
 final class AvatarUrlProviderTest extends Framework\TestCase
 {


### PR DESCRIPTION
This PR

* [x] renames the vendor namespace `Localheinz` to `Ergebnis` after the move to @ergebnis