### PR TITLE
Fix: Remove inappropriate replace configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.2.0...master`][0.2.0...master].
+For a full diff see [`0.2.1...master`][0.2.1...master].
+
+## [`0.2.1`][0.2.1]
+
+For a full diff see [`0.2.0...0.2.1`][0.2.0...0.2.1].
+
+### Fixed
+
+* Removed an inappropriate `replace` configuration from `composer.json` ([#20]), by [@localheinz]
 
 ## [`0.2.0`][0.2.0]
 
@@ -60,14 +68,17 @@ For a full diff see [`b2e46fd...0.1.0`][b2e46fd...0.1.0].
 
 [0.1.0]: https://github.com/ergebnis/faker-provider/tag/0.1.0
 [0.2.0]: https://github.com/ergebnis/faker-provider/tag/0.2.0
+[0.2.1]: https://github.com/ergebnis/faker-provider/tag/0.2.1
 
 [b2e46fd...0.1.0]: https://github.com/ergebnis/faker-provider/compare/b2e46fd...0.1.0
 [0.1.0...0.2.0]: https://github.com/ergebnis/faker-provider/compare/0.1.0...0.2.0
-[0.2.0...master]: https://github.com/ergebnis/faker-provider/compare/0.2.0...master
+[0.2.0...0.2.1]: https://github.com/ergebnis/faker-provider/compare/0.2.0...0.2.1
+[0.2.1...master]: https://github.com/ergebnis/faker-provider/compare/0.2.1...master
 
 [#1]: https://github.com/ergebnis/faker-provider/pull/1
 [#4]: https://github.com/ergebnis/faker-provider/pull/4
 [#18]: https://github.com/ergebnis/faker-provider/pull/18
+[#20]: https://github.com/ergebnis/faker-provider/pull/20
 
 [@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,6 @@
     "php": "^7.2",
     "fzaninotto/faker": "^1.9.0"
   },
-  "replace": {
-    "localheinz/faker-provider": "*"
-  },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.0.0",
     "ergebnis/phpstan-rules": "~0.14.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e969c4a2d91678450c1b27aa068d6f7f",
+    "content-hash": "6fd5cd2fa52d4974ad0c0c5887067bb7",
     "packages": [
         {
             "name": "fzaninotto/faker",


### PR DESCRIPTION
This PR

* [x] removes an inappropriate `replace` configuration from `composer.json`

Follows #18.